### PR TITLE
Add `$GITHUB_WORKSPACE` as a safe directory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,6 +27,8 @@ pandoc -v
 echo -ne "${BOLD}Babel: ${PLAIN}"
 babel --version
 
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
 echo -e "\n${BOLD}Generating Site ${NAME} at commit ${GITHUB_SHA}.${PLAIN}"
 hugo mod get
 hugo ${INPUT_ARGS} -d "${INPUT_BUILDPATH}"


### PR DESCRIPTION
In the context of a GitHub action, mark `$GITHUB_WORKSPACE` as a safe
directory.

Related:
- https://github.blog/2022-04-12-git-security-vulnerability-announced/
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765