### PR TITLE
Fix hugoVersion configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM registry.gitlab.com/pages/hugo/hugo_extended:latest
 
 # Hugo External Dependecies
 RUN apk add --update --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-  py-pygments asciidoctor npm py3-rst ca-certificates libc6-compat libstdc++ git go openssl \
-  && rm -rf /var/cache/apk/* 
+  py-pygments asciidoctor npm ca-certificates libc6-compat libstdc++ git go openssl tar gzip \
+  && rm -rf /var/cache/apk/*
 
 RUN npm install --unsafe-perm=true -g postcss postcss-cli autoprefixer \
   && npm install --unsafe-perm=true -g @babel/cli @babel/core @babel/preset-env
@@ -12,7 +12,7 @@ RUN wget https://github.com/jgm/pandoc/releases/download/2.9.1.1/pandoc-2.9.1.1-
   && tar xvzf pandoc-2.9.1.1-linux-amd64.tar.gz --strip-components 1 -C /usr/local \
   && rm pandoc-2.9.1.1-linux-amd64.tar.gz \
   && mkdir /site
-  
+
 COPY ./docker-entrypoint.sh /entrypoint.sh
 
 WORKDIR /site

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://chabad360/hugo'
+  image: 'Dockerfile'
   entrypoint: '/entrypoint.sh'
 
 branding:
-  icon: 'box'  
+  icon: 'box'
   color: 'yellow'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,9 +7,10 @@ BOLD='\033[1;37m'
 if [ "${INPUT_HUGOVERSION}" ]; then
   echo -e "\n${BOLD}Downloading Hugo version ${INPUT_HUGOVERSION}.${PLAIN}"
   wget "https://github.com/gohugoio/hugo/releases/download/v$(echo "${INPUT_HUGOVERSION}" | grep -o  "[0-9]\+.[0-9]\+.[0-9]\+")/hugo_${INPUT_HUGOVERSION}_Linux-64bit.tar.gz"
-  tar xzvf hugo*
+  gzip --decompress hugo_*
+  tar -xvf hugo_*
   mv hugo /usr/bin/hugo
-  rm hugo*
+  rm hugo_*
 fi
 
 


### PR DESCRIPTION
## Overview

Tried using `hugoVersion: 'extended_0.126.2'` and got some errors:

```
Downloading Hugo version extended_0.126.2.
Connecting to github.com (140.82.114.4:443)
Connecting to objects.githubusercontent.com (185.199.108.133:443)
saving to 'hugo_extended_0.126.2_Linux-64bit.tar.gz'
hugo_extended_0.126. 100% |********************************| 21.1M  0:00:00 ETA
'hugo_extended_0.126.2_Linux-64bit.tar.gz' saved
tar: invalid magic
tar: short read
tar: hugo_extended_0.126.2_Linux-64bit.tar.gz: not found in archive
```

In short, successful download, unsuccessful ungzip+untar. And I'm not sure why! I wasn't able to reproduce this locally via Docker, frustratingly I only saw this when using through a Github Action. 

## Solution?

Through trial and error I settled on the approach here to resolve in my case:
* apk add gzip
* manually decompress with gzip, then have tar untar a non-compressed file
* change `rm hugo*` to rm `hugo_*` to accomodate `hugo.toml`

Just to make build testing work: 
* Change Docker to dynamically built image 
* Remove `py3-rst` because it does not seem to be available anymore

The question mark is next to solution because it very much looks like I'm missing something about how this works in Github Actions vs my local Docker. 🤷 

However, this does appear to work _more_ than the current version, so that's something 🤔 